### PR TITLE
Fix TLS parameter name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You just need to enable the tls mode as the following:
 
 ```ruby
   task :production => :common do
-    set :tls, true
+    set :tlsverify, true
     # ...
   end
 ```


### PR DESCRIPTION
There is a typo in the TLS section in README. TLS is enabled with `tlsverify` parameter.
