### PR TITLE
Build Service instances from a hash. Construct in deploy_dsl.rb.

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -1,5 +1,6 @@
 require_relative 'docker_server_group'
 require_relative 'docker_server'
+require_relative 'service'
 require 'uri'
 
 module Centurion::DeployDSL
@@ -70,11 +71,14 @@ module Centurion::DeployDSL
   end
 
   def defined_service
-    service = fetch(:service, {})
-    service.image = fetch(:image)
-    service.hostname = fetch(:container_hostname)
-    service.dns = fetch(:custom_dns)
-    service
+    fetch(:service,
+      Centurion::Service.from_hash(
+        fetch(:project),
+        image:    fetch(:image),
+        hostname: fetch(:container_hostname),
+        dns:      fetch(:custom_dns)
+      )
+    )
   end
 
   def defined_health_check

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -2,7 +2,28 @@ require 'spec_helper'
 require 'centurion/service'
 
 describe Centurion::Service do
-  let(:service) { Centurion::Service.new(:redis) }
+  let(:service)  { Centurion::Service.new(:redis) }
+  let(:hostname) { 'shakespeare' }
+  let(:image)    { 'redis' }
+
+  it 'creates a service from a hash' do
+    svc = Centurion::Service.from_hash(
+      'mycontainer',
+      image: image,
+      hostname: hostname,
+      dns: nil,
+      volumes: [ { host_volume: '/foo', container_volume: '/foo/bar' } ],
+      port_bindings: [ { host_port: 12340, container_port: 80, type: 'tcp' } ]
+    )
+
+    expect(svc.name). to eq('mycontainer')
+    expect(svc.hostname).to eq(hostname)
+    expect(svc.dns).to be_nil
+    expect(svc.volumes.size).to eq(1)
+    expect(svc.volumes.first.host_volume).to eq('/foo')
+    expect(svc.port_bindings.size).to eq(1)
+    expect(svc.port_bindings.first.container_port).to eq(80)
+  end
 
   it 'has an associated hostname' do
     service.hostname = 'example.com'


### PR DESCRIPTION
This should fix the issue with the default value of `defined_service` and also encapsulates the definition logic in the class in a class method rather than externally.
